### PR TITLE
Add 2025-2026 school year calendar

### DIFF
--- a/teacher-calendar.html
+++ b/teacher-calendar.html
@@ -22,8 +22,197 @@
   </header>
   <main>
     <h1>Calendar</h1>
+
     <section>
-      <p>Calendar events will be listed here.</p>
+      <h2>April 2025 (pre-SY)</h2>
+      <ul>
+        <li>7–8: Fourth quarter exams (prior SY)</li>
+        <li>9: Day of Valor (holiday)</li>
+        <li>10–11: EOSY deliberation of honors</li>
+        <li>14–15: EOSY rites</li>
+        <li>16: Start of teachers’ 30-day EOSY break</li>
+        <li>17: Maundy Thursday (holiday) · 18: Good Friday (holiday) · 19: Black Saturday (special non-working)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>May 2025 (pre-SY)</h2>
+      <ul>
+        <li>1: Labor Day (holiday)</li>
+        <li>8: Start of BBM &amp; summer remedials</li>
+        <li>12: National &amp; local election day</li>
+        <li>13: Start of literacy remediation/learning camp (by region)</li>
+        <li>13–16: Operation Linis</li>
+        <li>19–23: NSPC &amp; NFOT</li>
+        <li>24–31: Palarong Pambansa</li>
+        <li>1–31: Start of training window for teachers/school leaders/teaching-related personnel (e.g., Gr 2,3,5,8 &amp; 11 pilot; ARAL tutors)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>June 2025</h2>
+      <ul>
+        <li>1: End of teachers’ EOSY break</li>
+        <li>6: End of training window; end of BBM/remedials/learning camp (by region)</li>
+        <li>9: Start of mandatory learner health assessment</li>
+        <li>9–13: Brigada Eskwela &amp; Enrollment · 9–20: Oplan Balik Eskwela</li>
+        <li>12: Independence Day (holiday)</li>
+        <li>16: Opening of classes &amp; start of Q1</li>
+        <li>16: Start of BoSY assessment window (CRLA, RMA, Phil-IRI, Phil-ECD, MFAT, etc.)</li>
+        <li>16–30: Gather &amp; submit BoSY data (class program, school forms, etc.)</li>
+        <li>23–24: DepEd founding anniversary activities</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>July 2025</h2>
+      <ul>
+        <li>4: End of mandatory learner health assessment</li>
+        <li>16: End of BoSY assessment window</li>
+        <li>15–17, 22–24, 29–31: Instructional leadership enhancement trainings (3 batches)</li>
+        <li>21–25: SELG/SSLG federation elections</li>
+        <li>28–31: Start of ELLN testing window</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>August 2025</h2>
+      <ul>
+        <li>1: End of ELLN window</li>
+        <li>20 &amp; 22: Q1 examinations</li>
+        <li>21: Ninoy Aquino Day (non-working)</li>
+        <li>22: End of Q1 · 25: National Heroes Day (holiday) · 26: Start of Q2</li>
+        <li>26–29: Start of NAT Grade 10 window</li>
+        <li>30: Parent–Teacher Conference (PTC) &amp; cards</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>September 2025</h2>
+      <ul>
+        <li>1: End of NAT G10 window</li>
+        <li>5: Start of National Teachers’ Month</li>
+        <li>8–26: NCAE testing window</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>October 2025</h2>
+      <ul>
+        <li>5: Culmination of Teachers’ Month &amp; World Teachers’ Day</li>
+        <li>12: PEPT (Luzon) · 19: PEPT (VisMin)</li>
+        <li>23–24: Q2 examinations · 24: End of Q2</li>
+        <li>27–31: Mid-School-Year wellness break (learners &amp; teachers)</li>
+        <li>31: All Saints’ Day Eve (special non-working)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>November 2025</h2>
+      <ul>
+        <li>1: All Saints’ Day (non-working) · 2: All Souls’ Day (holiday)</li>
+        <li>3: Start of Q3</li>
+        <li>8: PTC &amp; cards</li>
+        <li>27: Araw ng Pagbasa · 30: Bonifacio Day (holiday)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>December 2025</h2>
+      <ul>
+        <li>8: Immaculate Conception (special non-working)</li>
+        <li>20–31: Year-end break</li>
+        <li>24: Christmas Eve (special) · 25: Christmas Day (holiday)</li>
+        <li>30: Rizal Day (holiday) · 31: Last day of year (special non-working)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>January 2026</h2>
+      <ul>
+        <li>1: New Year (holiday) · 5: Classes resume</li>
+        <li>19: Start of NAT Grade 12 window</li>
+        <li>22–23: Q3 examinations · 23: End of Q3 · 26: Start of Q4</li>
+        <li>31: Start of Early Registration (Kinder; Grades 1,7,11; OSCYA; transferees)</li>
+        <li>31: PTC &amp; cards</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>February 2026</h2>
+      <ul>
+        <li>2–6: End of NAT G12 window</li>
+        <li>17: Chinese New Year (holiday)</li>
+        <li>18: Start of EoSY assessment window (CRLA, RMA, Phil-IRI, Phil-ECD, etc.)</li>
+        <li>22: A&amp;E Test</li>
+        <li>27: End of Early Registration (Kinder; Grades 1,7,11; OSCYA; transferees)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>March 2026</h2>
+      <ul>
+        <li>9–20: Administer EoSY CRLA/RMA/Phil-IRI</li>
+        <li>18: End of EoSY assessment window</li>
+        <li>19–20: Q4 examinations</li>
+        <li>23–27: Deliberation of honors</li>
+        <li>30–31: EOSY rites (also last class day; SY ends Mar 31)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>April 2026 (post-SY)</h2>
+      <ul>
+        <li>1: PTC &amp; card distribution · Start of teachers’ 30-day EOSY break</li>
+        <li>2: Maundy Thursday (holiday) · 3: Good Friday (holiday)</li>
+        <li>9: Day of Valor (holiday)</li>
+        <li>27–30: NSPC &amp; NFOT</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>May 2026 (post-SY)</h2>
+      <ul>
+        <li>1: End of NSPC/NFOT; end of teachers’ 30-day EOSY break; Labor Day (holiday)</li>
+        <li>4: Start of EOSY intervention program</li>
+        <li>4–8: Palarong Pambansa</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>June 2026 (pre-next SY)</h2>
+      <ul>
+        <li>1–5: Brigada Eskwela &amp; Enrollment · 1–12: Oplan Balik Eskwela</li>
+        <li>8: Indicative opening of SY 2026–2027; start of Q1 (next SY)</li>
+        <li>TBA: Eid al-Adha (date to be announced)</li>
+      </ul>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>Class-day count (SY 2025–2026)</h2>
+      <p>Jun 11 · Jul 23 · Aug 20 · Sep 22 · Oct 23 · Nov 21 · Dec 14 · Jan 21 · Feb 19 · Mar 23 — Total: 197 class days.</p>
+      <p>Department of Education Philippines</p>
+    </section>
+
+    <section>
+      <h2>Official references</h2>
+      <p>DepEd Order No. 012, s. 2025 and its Enclosures (Monthly School Calendar of Activities). Opening/ending dates: June 16, 2025 – March 31, 2026.</p>
+      <p>Department of Education Philippines</p>
     </section>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Populate teacher calendar with detailed events from April 2025 through June 2026
- Include class-day counts and official references for SY 2025-2026

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ecfcf98832eb761733ca505c8d6