### PR TITLE
Revise teacher dashboard layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,11 @@ body {
 
 /* Layout helpers */
 .container { max-width: var(--container); margin: 28px auto; padding: 0 var(--pad); }
-.grid { display: grid; gap: var(--gap); grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.grid { display: grid; gap: var(--gap); grid-template-columns: repeat(2, 1fr); }
+.row { display:flex; gap:12px; flex-wrap:wrap; align-items:center; margin:12px 0; }
+@media (max-width: 640px) {
+  .grid { grid-template-columns: 1fr; }
+}
 
 /* Cards */
 .card {

--- a/teacher-dashboard.html
+++ b/teacher-dashboard.html
@@ -24,31 +24,7 @@
     <h1>Teacher Dashboard</h1>
     <div class="grid">
       <div class="card">
-        <h2>Today's Schedule</h2>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Subject</th>
-              <th>Section</th>
-              <th>Room</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>8:00 AM</td>
-              <td>Math</td>
-              <td>ABM 11</td>
-              <td>101</td>
-              <td><a class="btn" href="./teacher-attendance.html">Attendance</a></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="card">
-        <h2>Grading Queue</h2>
+        <h2>Gradinghub</h2>
         <div class="row">
           <span class="badge">Pending: 3</span>
           <a class="btn" href="./teacher-gradinghub.html">Open Gradinghub</a>
@@ -63,15 +39,6 @@
           <li>Field trip schedule available</li>
         </ul>
         <a class="btn" href="./teacher-announcements.html">View all</a>
-      </div>
-
-      <div class="card">
-        <h2>Quick Actions</h2>
-        <div class="row">
-          <a class="btn" href="./teacher-gradinghub.html">Open Gradinghub</a>
-          <a class="btn" href="./teacher-announcements.html">Post Announcement</a>
-          <a class="btn" href="./teacher-files.html">Upload File</a>
-        </div>
       </div>
 
       <div class="card">


### PR DESCRIPTION
## Summary
- Remove schedule and quick action cards from teacher dashboard
- Present remaining widgets in a 2x2 grid with Gradinghub first
- Add global flex row helper and responsive grid styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f41226ed0832e9669227d9d8f55db