### PR TITLE
Update dashboard with August calendar and latest announcement

### DIFF
--- a/teacher-dashboard.html
+++ b/teacher-dashboard.html
@@ -32,22 +32,30 @@
       </div>
 
       <div class="card">
-        <h2>Latest Announcements</h2>
+        <h2>Latest Announcement</h2>
+        <h3>Launching the New MSHS Portal</h3>
+        <p class="muted">Explore the updated portal built to streamline your daily tasks.</p>
+        <h4>Features</h4>
         <ul class="muted">
-          <li>Staff meeting at 3 PM</li>
-          <li>Grade submissions due Friday</li>
-          <li>Field trip schedule available</li>
+          <li>Unified dashboard for quick access to tools</li>
+          <li>Real-time announcements and calendar views</li>
+          <li>Easy file uploads and a powerful grading hub</li>
         </ul>
         <a class="btn" href="./teacher-announcements.html">View all</a>
       </div>
 
       <div class="card">
-        <h2>Calendar Peek</h2>
+        <h2>Calendar</h2>
+        <h3>August 2025</h3>
         <ul>
-          <li>Mon: Dept. meeting</li>
-          <li>Wed: Workshop</li>
-          <li>Fri: Exam day</li>
+          <li>1: End of ELLN window</li>
+          <li>20 &amp; 22: Q1 examinations</li>
+          <li>21: Ninoy Aquino Day (non-working)</li>
+          <li>22: End of Q1 · 25: National Heroes Day (holiday) · 26: Start of Q2</li>
+          <li>26–29: Start of NAT Grade 10 window</li>
+          <li>30: Parent–Teacher Conference (PTC) &amp; cards</li>
         </ul>
+        <p class="muted">Department of Education Philippines</p>
         <a class="btn" href="./teacher-calendar.html">Open Calendar</a>
       </div>
 


### PR DESCRIPTION
## Summary
- Show the "Launching the New MSHS Portal" announcement with feature list on the dashboard.
- Replace the calendar peek with an August 2025 calendar section sourced from the calendar page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f483815a4832e88af70ed3a86c693