### PR TITLE
fix: prevent dashboard buttons from covering text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,7 @@ body {
   appearance: none; border: 1px solid transparent; cursor: pointer;
   padding: .55rem .9rem; border-radius: 10px; font-weight: 600;
   background: var(--accent); color: white; transition: transform var(--trans), background var(--trans);
+  display: inline-block; position: relative;
 }
 .btn:hover { background: var(--accent-hover); transform: translateY(-1px); }
 .btn.ghost { background: transparent; color: var(--text); border-color: var(--border); }


### PR DESCRIPTION
## Summary
- make buttons inline elements so they no longer overlap text content

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4bb0859c832e8c7fa72ef6f13f92