### PR TITLE
Move hero header above navigation bar

### DIFF
--- a/teacher-announcements.html
+++ b/teacher-announcements.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Announcements</h1>
     <div class="card">

--- a/teacher-calendar.html
+++ b/teacher-calendar.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Calendar</h1>
     <div class="grid">

--- a/teacher-dashboard.html
+++ b/teacher-dashboard.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html" aria-current="page">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Teacher Dashboard</h1>
     <div class="grid">

--- a/teacher-files.html
+++ b/teacher-files.html
@@ -16,8 +16,22 @@
 </head>
 <body>
   <!-- Centered dark nav -->
-  <header class="topbar">
-    <nav class="center-nav" aria-label="Main">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav" aria-label="Main">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -29,20 +43,6 @@
       <a href="./teacher-files.html" aria-current="page">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
 
   <main class="container">
     <h1>Upload / Download</h1>

--- a/teacher-gradinghub.html
+++ b/teacher-gradinghub.html
@@ -11,8 +11,22 @@
 </head>
 <body>
   <!-- Centered dark nav -->
-  <header class="topbar">
-    <nav class="center-nav" aria-label="Main">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav" aria-label="Main">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html" aria-current="page">Gradinghub</a>
@@ -24,20 +38,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
 
   <main class="container">
     <h1>Grading Hub</h1>

--- a/teacher-help.html
+++ b/teacher-help.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Help</h1>
     <div class="grid">

--- a/teacher-schedule.html
+++ b/teacher-schedule.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Schedule</h1>
     <p>Some browsers block in-page PDF preview—use Download if the preview doesn’t load.</p>

--- a/teacher-settings.html
+++ b/teacher-settings.html
@@ -7,8 +7,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <nav class="center-nav">
+  <header>
+    <section class="hero" role="banner" aria-label="MSHS Portal banner">
+      <div class="hero-content">
+        <div class="hero-kicker">MSHS Portal</div>
+        <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
+        <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
+        <p class="hero-meta">
+          <span>Email: 342203@deped.gov.ph</span>
+          <span class="dot"></span>
+          <span>Phone: (043) 773-7606</span>
+          <span class="dot"></span>
+          <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
+        </p>
+      </div>
+    </section>
+    <nav class="topbar center-nav">
       <a href="./index.html">Home</a>
       <a href="./teacher-dashboard.html">Dashboard</a>
       <a href="./teacher-gradinghub.html">Gradinghub</a>
@@ -20,20 +34,6 @@
       <a href="./teacher-files.html">Upload/Download</a>
     </nav>
   </header>
-  <section class="hero" role="banner" aria-label="MSHS Portal banner">
-    <div class="hero-content">
-      <div class="hero-kicker">MSHS Portal</div>
-      <p class="hero-title" role="heading" aria-level="1">MATAASNAKAHOY SENIOR HIGH SCHOOL</p>
-      <p class="hero-sub">"Education with Heart, Growth with Purpose"</p>
-      <p class="hero-meta">
-        <span>Email: 342203@deped.gov.ph</span>
-        <span class="dot"></span>
-        <span>Phone: (043) 773-7606</span>
-        <span class="dot"></span>
-        <span>FB: DepEd Tayo Mataasnakahoy SHS</span>
-      </p>
-    </div>
-  </section>
   <main class="container">
     <h1>Settings</h1>
     <div class="grid">


### PR DESCRIPTION
## Summary
- Show the site hero banner above the navigation bar on teacher pages
- Keep navigation sticky by applying `topbar` to `<nav>`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd0ba9e80832e82b04e3f9a2c53ec