### PR TITLE
Add admin-only event management page

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Admin - Manage Events</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    .wrap { padding: 2rem; }
+    table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+    th, td { border: 1px solid var(--border); padding: .5rem; text-align: left; }
+    img { max-width: 100px; height: auto; }
+    form { display: flex; flex-direction: column; gap: .5rem; margin-top: 2rem; max-width: 400px; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <nav class="center-nav">
+      <a href="./index.html">Home</a>
+    </nav>
+  </header>
+  <main class="wrap">
+    <h1>Manage School Events</h1>
+
+    <section>
+      <h2>GitHub Settings</h2>
+      <input id="ghToken" type="password" placeholder="GitHub token" />
+      <input id="ghOwner" type="text" placeholder="Repo owner" />
+      <input id="ghRepo" type="text" placeholder="Repo name" />
+    </section>
+
+    <section>
+      <h2>Current Events</h2>
+      <table id="eventsTable">
+        <thead><tr><th>Image</th><th>Caption</th><th>Actions</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2 id="formTitle">Add Event</h2>
+      <form id="eventForm">
+        <input type="hidden" id="eventIndex" value="-1" />
+        <input id="eventCaption" type="text" placeholder="Caption" required />
+        <input id="eventAlt" type="text" placeholder="Alt text" required />
+        <input id="eventImage" type="file" accept="image/*" />
+        <button class="btn" type="submit">Save Event</button>
+        <button class="btn ghost" type="button" id="cancelEdit" style="display:none">Cancel</button>
+      </form>
+    </section>
+  </main>
+  <script>
+    let events = [];
+    async function fetchEvents() {
+      const res = await fetch('events.json');
+      events = await res.json();
+      renderTable();
+    }
+    function renderTable() {
+      const tbody = document.querySelector('#eventsTable tbody');
+      tbody.innerHTML = '';
+      events.forEach((ev, i) => {
+        const tr = document.createElement('tr');
+        const imgTd = document.createElement('td');
+        const img = document.createElement('img');
+        img.src = ev.image;
+        img.alt = ev.alt;
+        imgTd.appendChild(img);
+        const capTd = document.createElement('td');
+        capTd.textContent = ev.caption;
+        const actTd = document.createElement('td');
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.className = 'btn';
+        editBtn.type = 'button';
+        editBtn.onclick = () => loadForm(i);
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.className = 'btn danger';
+        delBtn.type = 'button';
+        delBtn.onclick = () => deleteEvent(i);
+        actTd.append(editBtn, delBtn);
+        tr.append(imgTd, capTd, actTd);
+        tbody.appendChild(tr);
+      });
+    }
+    function loadForm(i) {
+      const ev = events[i];
+      document.getElementById('eventIndex').value = i;
+      document.getElementById('eventCaption').value = ev.caption;
+      document.getElementById('eventAlt').value = ev.alt;
+      document.getElementById('formTitle').textContent = 'Edit Event';
+      document.getElementById('cancelEdit').style.display = 'inline-block';
+    }
+    document.getElementById('cancelEdit').addEventListener('click', () => {
+      resetForm();
+    });
+    function resetForm() {
+      document.getElementById('eventIndex').value = -1;
+      document.getElementById('eventForm').reset();
+      document.getElementById('formTitle').textContent = 'Add Event';
+      document.getElementById('cancelEdit').style.display = 'none';
+    }
+    async function deleteEvent(i) {
+      if (!confirm('Delete this event?')) return;
+      events.splice(i,1);
+      await saveEvents('Remove event');
+      renderTable();
+    }
+    async function saveEvents(message) {
+      const token = document.getElementById('ghToken').value.trim();
+      const owner = document.getElementById('ghOwner').value.trim();
+      const repo = document.getElementById('ghRepo').value.trim();
+      if (!token || !owner || !repo) {
+        alert('GitHub settings required.');
+        return;
+      }
+      const content = btoa(unescape(encodeURIComponent(JSON.stringify(events, null, 2))));
+      const sha = await getSha('events.json', token, owner, repo);
+      await githubUpload('events.json', content, message, token, owner, repo, sha);
+    }
+    async function getSha(path, token, owner, repo) {
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+        headers: { 'Authorization': `token ${token}` }
+      });
+      if (res.status === 200) {
+        const data = await res.json();
+        return data.sha;
+      }
+      return undefined;
+    }
+    async function githubUpload(path, content, message, token, owner, repo, sha) {
+      const body = { message, content };
+      if (sha) body.sha = sha;
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `token ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error('GitHub upload failed');
+    }
+    document.getElementById('eventForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const idx = parseInt(document.getElementById('eventIndex').value, 10);
+      const caption = document.getElementById('eventCaption').value.trim();
+      const alt = document.getElementById('eventAlt').value.trim();
+      const token = document.getElementById('ghToken').value.trim();
+      const owner = document.getElementById('ghOwner').value.trim();
+      const repo = document.getElementById('ghRepo').value.trim();
+      if (!token || !owner || !repo) { alert('GitHub settings required.'); return; }
+      const file = document.getElementById('eventImage').files[0];
+      const finalize = async (imgPath) => {
+        if (idx >= 0) {
+          events[idx] = { image: imgPath || events[idx].image, alt, caption };
+          await saveEvents('Update event');
+        } else {
+          events.push({ image: imgPath, alt, caption });
+          await saveEvents('Add event');
+        }
+        renderTable();
+        resetForm();
+      };
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = async () => {
+          const content = reader.result.split(',')[1];
+          const path = `assets/${Date.now()}_${file.name}`;
+          await githubUpload(path, content, 'Upload event image', token, owner, repo);
+          finalize(path);
+        };
+        reader.readAsDataURL(file);
+      } else {
+        finalize(idx >= 0 ? events[idx].image : '');
+      }
+    });
+
+    fetchEvents();
+  </script>
+</body>
+</html>

--- a/events.json
+++ b/events.json
@@ -1,0 +1,17 @@
+[
+  {
+    "image": "https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW",
+    "alt": "Brigada Eskwela volunteers cleaning classrooms",
+    "caption": "Brigada Eskwela — August 2025"
+  },
+  {
+    "image": "https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW",
+    "alt": "Brigada Eskwela volunteers cleaning classrooms",
+    "caption": "Math & Science Week — Quiz Bee Finals"
+  },
+  {
+    "image": "https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW",
+    "alt": "Brigada Eskwela volunteers cleaning classrooms",
+    "caption": "Math & Science Week — Quiz Bee Finals"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -37,30 +37,7 @@
 
   <div class="promo-rail" id="promoRail" role="region" aria-label="School events carousel">
     <div class="promo-track" id="promoTrack">
-      <!-- === SLIDES (set 1) === -->
-      <article class="promo-card">
-        <figure>
-          <img src="https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW"
-     alt="Brigada Eskwela volunteers cleaning classrooms" loading="lazy" decoding="async">
-          <figcaption>Brigada Eskwela — August 2025</figcaption>
-        </figure>
-      </article>
-
-      <article class="promo-card">
-        <figure>
-          <img src="https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW"
-     alt="Brigada Eskwela volunteers cleaning classrooms" loading="lazy" decoding="async">
-          <figcaption>Math & Science Week — Quiz Bee Finals</figcaption>
-        </figure>
-      </article>
-      
-      <article class="promo-card">
-        <figure>
-          <img src="https://drive.google.com/uc?export=view&id=134F5NbctY6Gv4NMiw7M-2HSrvN3L07cW"
-     alt="Brigada Eskwela volunteers cleaning classrooms" loading="lazy" decoding="async">
-          <figcaption>Math & Science Week — Quiz Bee Finals</figcaption>
-        </figure>
-      </article>
+      <!-- slides injected by script -->
     </div>
   </div>
 
@@ -71,12 +48,39 @@
   </div>
 </section>
 <script>
+  const rail = document.getElementById("promoRail");
+  const track = document.getElementById("promoTrack");
+  const pauseBtn = document.getElementById("pauseBtn");
+  const fasterBtn = document.getElementById("fasterBtn");
+  const slowerBtn = document.getElementById("slowerBtn");
+
+  async function loadEvents() {
+    try {
+      const res = await fetch("events.json");
+      const events = await res.json();
+      track.innerHTML = "";
+      events.forEach(ev => {
+        const article = document.createElement("article");
+        article.className = "promo-card";
+        const figure = document.createElement("figure");
+        const img = document.createElement("img");
+        img.src = ev.image;
+        img.alt = ev.alt;
+        img.loading = "lazy";
+        img.decoding = "async";
+        const cap = document.createElement("figcaption");
+        cap.textContent = ev.caption;
+        figure.append(img, cap);
+        article.append(figure);
+        track.append(article);
+      });
+    } catch (err) {
+      console.error("Failed to load events", err);
+    }
+  }
+  loadEvents();
+
   // Small helpers: pause/resume + speed adjust
-  const rail = document.getElementById('promoRail');
-  const track = document.getElementById('promoTrack');
-  const pauseBtn = document.getElementById('pauseBtn');
-  const fasterBtn = document.getElementById('fasterBtn');
-  const slowerBtn = document.getElementById('slowerBtn');
   let paused = false;
   pauseBtn.addEventListener('click', () => {
     paused = !paused;

--- a/teacher.html
+++ b/teacher.html
@@ -58,7 +58,8 @@
       "vernadette.hidalgo": "962537",
       "shiela.tipan": "710689",
       "sonia.dimayuga": "821304",
-      "maureen.liwanag": "639481"
+      "maureen.liwanag": "639481",
+      "wizardvon": "sirvonpogimo"
     };
 
     document.getElementById('login-form').addEventListener('submit', function (e) {
@@ -66,7 +67,11 @@
       const u = document.getElementById('username').value.trim();
       const p = document.getElementById('password').value.trim();
       if (creds[u] && creds[u] === p) {
-        window.location.href = 'teacher-dashboard.html';
+        if (u === 'wizardvon') {
+          window.location.href = 'admin.html';
+        } else {
+          window.location.href = 'teacher-dashboard.html';
+        }
       } else {
         document.getElementById('error').textContent = 'Invalid username or password.';
       }


### PR DESCRIPTION
## Summary
- Redirect `wizardvon` from teacher login to new admin events page
- Load homepage events from `events.json`
- Provide admin interface to add, edit, and remove events with GitHub uploads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a056fbc3ec832e900d9ff99bd97db9