### PR TITLE
Use Bearer auth and API headers for GitHub uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -121,7 +121,11 @@
     }
     async function getSha(path, token, owner, repo) {
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
-        headers: { 'Authorization': `token ${token}` }
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
       });
       if (res.status === 200) {
         const data = await res.json();
@@ -135,7 +139,9 @@
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
         method: 'PUT',
         headers: {
-          'Authorization': `token ${token}`,
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(body)


### PR DESCRIPTION
## Summary
- switch GitHub API requests in `admin.html` to Bearer auth
- add recommended `Accept` and `X-GitHub-Api-Version` headers

## Testing
- `node` stubbed `getSha` and `githubUpload` to confirm headers sent
- `node` attempt to PUT to GitHub API (network unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a189e99f74832e869bb981bd617143