### PR TITLE
Improve error handling for admin GitHub uploads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -104,7 +104,11 @@
     async function deleteEvent(i) {
       if (!confirm('Delete this event?')) return;
       events.splice(i,1);
-      await saveEvents('Remove event');
+      try {
+        await saveEvents('Remove event');
+      } catch (err) {
+        alert(err.message);
+      }
       renderTable();
     }
     async function saveEvents(message) {
@@ -117,7 +121,12 @@
       }
       const content = btoa(unescape(encodeURIComponent(JSON.stringify(events, null, 2))));
       const sha = await getSha('events.json', token, owner, repo);
-      await githubUpload('events.json', content, message, token, owner, repo, sha);
+      try {
+        await githubUpload('events.json', content, message, token, owner, repo, sha);
+      } catch (err) {
+        alert(err.message);
+        throw err;
+      }
     }
     async function getSha(path, token, owner, repo) {
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
@@ -146,7 +155,15 @@
         },
         body: JSON.stringify(body)
       });
-      if (!res.ok) throw new Error('GitHub upload failed');
+      if (!res.ok) {
+        let text = '';
+        try {
+          text = await res.text();
+        } catch (e) {
+          // ignore
+        }
+        throw new Error(`GitHub upload failed (${res.status}): ${text}`);
+      }
     }
     document.getElementById('eventForm').addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -161,10 +178,20 @@
       const finalize = async (imgPath) => {
         if (idx >= 0) {
           events[idx] = { image: imgPath || events[idx].image, alt, caption };
-          await saveEvents('Update event');
+          try {
+            await saveEvents('Update event');
+          } catch (err) {
+            alert(err.message);
+            return;
+          }
         } else {
           events.push({ image: imgPath, alt, caption });
-          await saveEvents('Add event');
+          try {
+            await saveEvents('Add event');
+          } catch (err) {
+            alert(err.message);
+            return;
+          }
         }
         renderTable();
         resetForm();
@@ -174,8 +201,12 @@
         reader.onload = async () => {
           const content = reader.result.split(',')[1];
           const path = `assets/${Date.now()}_${file.name}`;
-          await githubUpload(path, content, 'Upload event image', token, owner, repo);
-          finalize(path);
+          try {
+            await githubUpload(path, content, 'Upload event image', token, owner, repo);
+            finalize(path);
+          } catch (err) {
+            alert(err.message);
+          }
         };
         reader.readAsDataURL(file);
       } else {


### PR DESCRIPTION
## Summary
- Include HTTP status and response text when GitHub uploads fail
- Surface failures from `saveEvents` and `githubUpload` via try/catch with `alert`

## Testing
- `node` (mocked)

------
https://chatgpt.com/codex/tasks/task_e_68a18aba9940832e9ae467a8c634cb2b