### PR TITLE
Replace event carousel with cards

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,27 +1,22 @@
 [
   {
-    "image": "assets/events/event1.svg",
-    "alt": "School Event1",
-    "caption": "Insert Caption of School Event Here"
+    "image": "https://drive.google.com/uc?export=view&id=sample1",
+    "alt": "Sample event 1",
+    "caption": "Insert caption of School Event 1"
   },
   {
-    "image": "assets/events/event2.svg",
-    "alt": "School Event2",
-    "caption": "Insert Caption of School Event Herer"
-  }
+    "image": "https://drive.google.com/uc?export=view&id=sample2",
+    "alt": "Sample event 2",
+    "caption": "Insert caption of School Event 2"
+  },
   {
-    "image": "assets/events/event3.svg",
-    "alt": "School Event3",
-    "caption": "Insert Caption of School Event Herer"
-  }
+    "image": "https://drive.google.com/uc?export=view&id=sample3",
+    "alt": "Sample event 3",
+    "caption": "Insert caption of School Event 3"
+  },
   {
-    "image": "assets/events/event4.svg",
-    "alt": "School Event4",
-    "caption": "Insert Caption of School Event Herer"
-  }
-  {
-    "image": "assets/events/event5.svg",
-    "alt": "School Event5",
-    "caption": "Insert Caption of School Event Herer"
+    "image": "https://drive.google.com/uc?export=view&id=sample4",
+    "alt": "Sample event 4",
+    "caption": "Insert caption of School Event 4"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -32,78 +32,6 @@
   </section>
   <main class="wrap">
     <div>
-<section class="promo" aria-labelledby="eventsTitle">
-  <h2 id="eventsTitle">School Events</h2>
-
-  <div class="promo-rail" id="promoRail" role="region" aria-label="School events carousel">
-    <div class="promo-track" id="promoTrack">
-      <!-- slides injected by script -->
-    </div>
-  </div>
-
-  <div class="promo-controls">
-    <button class="btn ghost" id="pauseBtn">⏸</button>
-    <button class="btn ghost" id="fasterBtn">➕</button>
-    <button class="btn ghost" id="slowerBtn">➖</button>
-  </div>
-</section>
-<script>
-  const rail = document.getElementById("promoRail");
-  const track = document.getElementById("promoTrack");
-  const pauseBtn = document.getElementById("pauseBtn");
-  const fasterBtn = document.getElementById("fasterBtn");
-  const slowerBtn = document.getElementById("slowerBtn");
-
-  async function loadEvents() {
-    try {
-      const res = await fetch("events.json");
-      const events = await res.json();
-      track.innerHTML = "";
-      events.forEach(ev => {
-        const article = document.createElement("article");
-        article.className = "promo-card";
-        const figure = document.createElement("figure");
-        const img = document.createElement("img");
-        img.src = ev.image;
-        img.alt = ev.alt;
-        img.loading = "lazy";
-        img.decoding = "async";
-        const cap = document.createElement("figcaption");
-        cap.textContent = ev.caption;
-        figure.append(img, cap);
-        article.append(figure);
-        track.append(article);
-      });
-    } catch (err) {
-      console.error("Failed to load events", err);
-    }
-  }
-  loadEvents();
-
-  // Small helpers: pause/resume + speed adjust
-  let paused = false;
-  pauseBtn.addEventListener('click', () => {
-    paused = !paused;
-    rail.classList.toggle('paused', paused);
-    pauseBtn.textContent = paused ? '▶' : '⏸';
-  });
-  function setSpeed(mult) {
-    // read current speed (e.g., "40s") and adjust
-    const current = getComputedStyle(track).getPropertyValue('--speed').trim() || '40s';
-    const n = parseFloat(current);
-    const unit = current.endsWith('ms') ? 'ms' : 's';
-    const newVal = Math.max(5, Math.min(120, n * mult)); // clamp between 5s and 120s
-    track.style.setProperty('--speed', newVal + unit);
-  }
-  fasterBtn.addEventListener('click', () => setSpeed(0.8));
-  slowerBtn.addEventListener('click', () => setSpeed(1.25));
-
-  // Keyboard: space to pause/resume
-  document.addEventListener('keydown', (e) => {
-    if (e.code === 'Space') { e.preventDefault(); pauseBtn.click(); }
-  });
-</script>
-
       <h1>Welcome!</h1>
       <p>This is the starting point for our Student & Teacher portal.</p>
       <div class="links">
@@ -112,5 +40,37 @@
       </div>
     </div>
   </main>
+
+  <section class="container" aria-labelledby="eventsTitle">
+    <h2 id="eventsTitle">School Events</h2>
+    <div class="grid" id="eventsGrid"></div>
+  </section>
+
+  <script>
+    async function loadEvents() {
+      try {
+        const res = await fetch("events.json");
+        const events = await res.json();
+        const grid = document.getElementById("eventsGrid");
+        grid.innerHTML = "";
+        events.forEach(ev => {
+          const article = document.createElement("article");
+          article.className = "card";
+          const img = document.createElement("img");
+          img.src = ev.image;
+          img.alt = ev.alt || "";
+          img.loading = "lazy";
+          img.decoding = "async";
+          const cap = document.createElement("p");
+          cap.textContent = ev.caption;
+          article.append(img, cap);
+          grid.append(article);
+        });
+      } catch (err) {
+        console.error("Failed to load events", err);
+      }
+    }
+    loadEvents();
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,15 @@ body {
 .card p { margin: 6px 0 0; color: var(--muted); }
 .card ul { margin: 0 0 8px 1.25rem; }
 
+.card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  display: block;
+  margin-bottom: 8px;
+}
+
 /* Tables */
 .table { width: 100%; border-collapse: collapse; background: var(--surface); border-radius: var(--radius); overflow: hidden; }
 .table th, .table td { padding: 12px 14px; border-bottom: 1px solid var(--border); text-align: left; }
@@ -101,70 +110,6 @@ input:focus, select:focus, textarea:focus, .btn:focus, a:focus {
 
 
 
-
-/* --- Promo carousel (continuous horizontal scroll) --- */
-.promo { margin-top: 8px; }
-.promo h2 { margin: 0 0 12px; font-size: 1.25rem; color: var(--text); }
-
-.promo-rail {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-
-/* fade edges for a pro look */
-.promo-rail::before,
-.promo-rail::after {
-  content: "";
-  position: absolute; top: 0; bottom: 0; width: 48px; z-index: 2;
-  pointer-events: none;
-  background: linear-gradient(to right, var(--surface), transparent);
-}
-.promo-rail::after {
-  right: 0; left: auto;
-  transform: scaleX(-1);
-}
-
-.promo-track {
-  --speed: 40s;               /* adjust speed: lower = faster */
-  display: flex; gap: 16px;
-  padding: 12px;
-  will-change: transform;
-  animation: promo-scroll var(--speed) linear infinite;
-}
-.promo-rail:hover .promo-track,
-.promo-rail.paused .promo-track { animation-play-state: paused; }
-
-@keyframes promo-scroll {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); } /* because we duplicate items */
-}
-
-.promo-card {
-  min-width: clamp(240px, 28vw, 360px);
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden;
-}
-.promo-card figure { margin: 0; }
-.promo-card img {
-  display: block; width: 100%;
-  aspect-ratio: 16/9; object-fit: cover;
-}
-.promo-card figcaption {
-  padding: 10px 12px;
-  font-size: .95rem; color: var(--muted);
-}
-
-/* tiny control bar */
-.promo-controls {
-  display: flex; justify-content: center; gap: 8px; margin-top: 10px;
-}
-.promo-controls .btn { padding: .45rem .75rem; font-weight: 600; }
 
 /* --- Text hero banner (no images) --- */
 .hero{position:relative;border-bottom:1px solid var(--border);


### PR DESCRIPTION
## Summary
- Replace scrolling events carousel with grid of event cards below the welcome section
- Style cards for images and load sample events from JSON (supports Google Drive links)
- Clean up obsolete promo carousel styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30167a424832eb95dda03ad7cca41