### PR TITLE
feat: adjust portal color scheme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,9 @@
 /* Global — professional dark theme */
 :root {
   color-scheme: dark;
-  --bg: #0b1220;           /* page background (charcoal / navy) */
-  --surface: #101826;      /* cards / header */
-  --surface-2: #0d1626;    /* subtle alt surface */
+  --bg: #0A122A;           /* page background (navy blue) */
+  --surface: #DADDD8;      /* cards / header */
+  --surface-2: #DADDD8;    /* subtle alt surface */
   --text: #e6eaf2;         /* primary text */
   --muted: #a3acc2;        /* secondary text */
   --border: #1f2a3a;       /* hairline borders */
@@ -32,7 +32,7 @@ body {
 .topbar {
   position: sticky; top: 0; z-index: 10;
   backdrop-filter: blur(8px);
-  background: color-mix(in oklab, var(--bg), white 3%);
+  background: #DADDD8; /* light background for top banner */
   border-bottom: 1px solid var(--border);
 }
 .center-nav {
@@ -114,10 +114,7 @@ input:focus, select:focus, textarea:focus, .btn:focus, a:focus {
 /* --- Text hero banner (no images) --- */
 .hero{position:relative;border-bottom:1px solid var(--border);
   padding:clamp(20px,5vw,40px) 0;
-  background:
-    radial-gradient(1200px 600px at 20% -20%, color-mix(in oklab, var(--accent), black 70%), transparent 60%),
-    radial-gradient(1200px 600px at 80% 120%, color-mix(in oklab, #14b8a6, black 80%), transparent 60%),
-    linear-gradient(180deg, color-mix(in oklab, var(--bg), white 4%), color-mix(in oklab, var(--bg), black 6%));
+  background:#800000; /* maroon banner */
 }
 .hero-content{max-width:var(--container);margin:0 auto;padding:0 var(--pad);text-align:center}
 .hero-kicker{text-transform:uppercase;letter-spacing:.08em;color:var(--accent-hover);font-weight:700;font-size:.95rem;opacity:.95}


### PR DESCRIPTION
## Summary
- set portal body to navy background and surfaces to light gray
- give hero banner maroon background
- lighten top navigation with neutral gray

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/school-portal/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a30deffd3c832eae02539cfcb9d324