### PR TITLE
Use direct Google Drive image links

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,6 +1,6 @@
 [
   {
-    "image": "https://drive.google.com/file/d/1AeqnQAHrxro_wKHiAYYBE1okEaBr_og0/view?usp=sharing",
+    "image": "https://drive.google.com/uc?export=view&id=1AeqnQAHrxro_wKHiAYYBE1okEaBr_og0",
     "alt": "Work Immersion",
     "caption": "Insert caption of School Event 1"
   },


### PR DESCRIPTION
## Summary
- replace Google Drive file links in events.json with direct download links

## Testing
- `curl -I https://drive.google.com/uc?export=view&id=1AeqnQAHrxro_wKHiAYYBE1okEaBr_og0` (403 forbidden)
- `curl -I https://drive.google.com/uc?export=view&id=sample2` (403 forbidden)
- `curl -I https://drive.google.com/uc?export=view&id=sample3` (403 forbidden)
- `curl -I https://drive.google.com/uc?export=view&id=sample4` (403 forbidden)
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a329bfb104832eb0778c9e404ad4ff