### PR TITLE
Improve GitHub upload handling

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -25,8 +25,10 @@
     <section>
       <h2>GitHub Settings</h2>
       <input id="ghToken" type="password" placeholder="github token" />
+      <p>Token must have 'contents: write' (or 'repo') scope.</p>
       <input id="ghOwner" type="text" placeholder="wizardvon" />
       <input id="ghRepo" type="text" placeholder="school-portal" />
+      <button id="resetSettings" class="btn ghost" type="button">Reset Settings</button>
     </section>
 
     <section>


### PR DESCRIPTION
## Summary
- switch GitHub API auth header to `token` scheme and surface 401/403 guidance
- persist admin GitHub settings via localStorage with reset option
- document required `contents: write` scope in admin UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a411bcb4c8832eb06b3accf613fa79